### PR TITLE
fix: add missing source for "having a cat"

### DIFF
--- a/library/things/things.json
+++ b/library/things/things.json
@@ -113,7 +113,7 @@
       "pet"
     ],
     "sources": [
-
+      "https://klima.com/blog/how-to-cut-your-pet-carbon-footprint-for-the-climate/"
     ],
     "kind": "thing"
   },


### PR DESCRIPTION
It was in the [original PR](https://github.com/howmuchgreen/howmuchcarbon/pull/4/files#diff-a27a51475e3c426af14039c561c0d1b1739562499d44f3fb1823e3a279a907c0R287) but must have disappear in some conflicts resolve.