### PR TITLE
feat(things): add bitcoin transaction, this website and netflix

### DIFF
--- a/library/things/things.json
+++ b/library/things/things.json
@@ -2,11 +2,7 @@
   {
     "name": "Sneakers",
     "co2Eq": "14 kg",
-    "keywords": [
-      "shoes",
-      "baskets",
-      "footwear"
-    ],
+    "keywords": ["shoes", "baskets", "footwear"],
     "sources": [
       "https://dspace.mit.edu/bitstream/handle/1721.1/102070/Olivetti_Manufacturing-focused.pdf?sequence=1&isAllowed=y"
     ],
@@ -15,10 +11,7 @@
   {
     "name": "Pixel 6",
     "co2Eq": "85 kg",
-    "keywords": [
-      "google",
-      "smartphone"
-    ],
+    "keywords": ["google", "smartphone"],
     "sources": [
       "https://www.gstatic.com/gumdrop/sustainability/pixel-6-product-environmental-report.pdf"
     ],
@@ -27,10 +20,7 @@
   {
     "name": "Pixel 5a",
     "co2Eq": "60 kg",
-    "keywords": [
-      "google",
-      "smartphone"
-    ],
+    "keywords": ["google", "smartphone"],
     "sources": [
       "https://www.gstatic.com/gumdrop/sustainability/pixel-5a-with-5g-product-environmental-report.pdf"
     ],
@@ -39,10 +29,7 @@
   {
     "name": "Pixel 5",
     "co2Eq": "85 kg",
-    "keywords": [
-      "smartphone",
-      "google"
-    ],
+    "keywords": ["smartphone", "google"],
     "sources": [
       "https://www.gstatic.com/gumdrop/sustainability/pixel5-product-environmental-report.pdf"
     ],
@@ -51,10 +38,7 @@
   {
     "name": "Burger (beef)",
     "co2Eq": "12 kg",
-    "keywords": [
-      "food",
-      "meat"
-    ],
+    "keywords": ["food", "meat"],
     "sources": [
       "https://www.forbes.com/sites/davidrvetter/2020/10/05/got-beef-heres-what-your-hamburger-is-doing-to-the-climate/?sh=ff998515206f"
     ],
@@ -63,9 +47,7 @@
   {
     "name": "Burger (chicken)",
     "co2Eq": "2 kg",
-    "keywords": [
-      "food"
-    ],
+    "keywords": ["food"],
     "sources": [
       "https://www.forbes.com/sites/davidrvetter/2020/10/05/got-beef-heres-what-your-hamburger-is-doing-to-the-climate/?sh=ff998515206f"
     ],
@@ -74,9 +56,7 @@
   {
     "name": "Burger (vegetarian)",
     "co2Eq": "1 kg",
-    "keywords": [
-      "food"
-    ],
+    "keywords": ["food"],
     "sources": [
       "https://www.forbes.com/sites/davidrvetter/2020/10/05/got-beef-heres-what-your-hamburger-is-doing-to-the-climate/?sh=ff998515206f"
     ],
@@ -84,22 +64,17 @@
   },
   {
     "name": "Having a kid",
-    "co2Eq": "59 ton",
-    "keywords": [
-
-    ],
+    "co2Eq": "1 ton",
+    "keywords": [],
     "sources": [
-      "https://www.theguardian.com/environment/2017/jul/12/want-to-fight-climate-change-have-fewer-children"
+      "https://usbeketrica.com/fr/article/renoncer-a-faire-des-enfants-pour-des-raisons-ecologiques-n-aura-qu-un-effet-mineur"
     ],
     "kind": "thing"
   },
   {
     "name": "Having a dog",
     "co2Eq": "770 kg",
-    "keywords": [
-      "pet",
-      "animal"
-    ],
+    "keywords": ["pet", "animal"],
     "sources": [
       "https://klima.com/blog/how-to-cut-your-pet-carbon-footprint-for-the-climate/"
     ],
@@ -108,10 +83,7 @@
   {
     "name": "Having a cat",
     "co2Eq": "310 kg",
-    "keywords": [
-      "animal",
-      "pet"
-    ],
+    "keywords": ["animal", "pet"],
     "sources": [
       "https://klima.com/blog/how-to-cut-your-pet-carbon-footprint-for-the-climate/"
     ],
@@ -124,9 +96,7 @@
     "sources": [
       "https://www.apple.com/environment/pdf/products/iphone/iPhone_12_PER_Oct2020.pdf"
     ],
-    "keywords": [
-      "apple"
-    ]
+    "keywords": ["apple"]
   },
   {
     "kind": "thing",
@@ -135,9 +105,7 @@
     "sources": [
       "https://www.apple.com/environment/pdf/products/iphone/iPhone_13_PER_Sept2021.pdf"
     ],
-    "keywords": [
-      "apple"
-    ]
+    "keywords": ["apple"]
   },
   {
     "kind": "thing",
@@ -146,9 +114,7 @@
     "sources": [
       "https://www.apple.com/environment/pdf/products/iphone/iPhone_13_mini_PER_Sept2021.pdf"
     ],
-    "keywords": [
-      "apple"
-    ]
+    "keywords": ["apple"]
   },
   {
     "kind": "thing",
@@ -157,9 +123,7 @@
     "sources": [
       "https://www.apple.com/environment/pdf/products/iphone/iPhone_13_Pro_PER_Sept2021.pdf"
     ],
-    "keywords": [
-      "apple"
-    ]
+    "keywords": ["apple"]
   },
   {
     "kind": "thing",
@@ -168,9 +132,7 @@
     "sources": [
       "https://www.apple.com/environment/pdf/products/iphone/iPhone_13_Pro_Max_PER_Sept2021.pdf"
     ],
-    "keywords": [
-      "apple"
-    ]
+    "keywords": ["apple"]
   },
   {
     "kind": "thing",
@@ -179,9 +141,7 @@
     "sources": [
       "https://www.apple.com/environment/pdf/products/ipad/iPad_PER_Sept2021.pdf"
     ],
-    "keywords": [
-      "apple"
-    ]
+    "keywords": ["apple"]
   },
   {
     "kind": "thing",
@@ -190,9 +150,7 @@
     "sources": [
       "https://www.apple.com/environment/pdf/products/ipad/iPadPro_11-inch_PER_Apr2021.pdf"
     ],
-    "keywords": [
-      "apple"
-    ]
+    "keywords": ["apple"]
   },
   {
     "kind": "thing",
@@ -201,9 +159,7 @@
     "sources": [
       "https://www.apple.com/environment/pdf/products/ipad/iPadPro_12.9-inch_PER_Mar2020.pdf"
     ],
-    "keywords": [
-      "apple"
-    ]
+    "keywords": ["apple"]
   },
   {
     "kind": "thing",
@@ -212,9 +168,7 @@
     "sources": [
       "https://www.apple.com/environment/pdf/products/watch/Apple_Watch_Series6_PER_sept2020.pdf"
     ],
-    "keywords": [
-      "apple"
-    ]
+    "keywords": ["apple"]
   },
   {
     "kind": "thing",
@@ -223,9 +177,7 @@
     "sources": [
       "https://www.apple.com/environment/pdf/products/notebooks/13-inch_MacBookPro_PER_Nov2020.pdf"
     ],
-    "keywords": [
-      "apple"
-    ]
+    "keywords": ["apple"]
   },
   {
     "kind": "thing",
@@ -234,9 +186,7 @@
     "sources": [
       "https://www.apple.com/environment/pdf/products/notebooks/14-inch_MacBook_Pro_PER_Oct2021.pdf"
     ],
-    "keywords": [
-      "apple"
-    ]
+    "keywords": ["apple"]
   },
   {
     "kind": "thing",
@@ -245,9 +195,7 @@
     "sources": [
       "https://www.apple.com/environment/pdf/products/notebooks/13-inch_MacBookAir_PER_Nov2020.pdf"
     ],
-    "keywords": [
-      "apple"
-    ]
+    "keywords": ["apple"]
   },
   {
     "kind": "thing",
@@ -256,9 +204,7 @@
     "sources": [
       "https://www.apple.com/environment/pdf/products/desktops/24-inch_iMac_PER_Apr2021.pdf"
     ],
-    "keywords": [
-      "apple"
-    ]
+    "keywords": ["apple"]
   },
   {
     "kind": "thing",
@@ -267,17 +213,13 @@
     "sources": [
       "https://gato-docs.its.txstate.edu/jcr:4646e321-9a29-41e5-880d-4c5ffe69e03e/thoughts_ereaders.pdf"
     ],
-    "keywords": [
-      "amazon"
-    ]
+    "keywords": ["amazon"]
   },
   {
     "kind": "thing",
     "name": "Beef (100g)",
     "co2Eq": "6 kg",
-    "keywords": [
-
-    ],
+    "keywords": [],
     "sources": [
       "https://www.vox.com/22787178/beyond-impossible-plant-based-vegetarian-meat-climate-environmental-impact-sustainability"
     ]
@@ -286,9 +228,7 @@
     "kind": "thing",
     "name": "Chicken (100g)",
     "co2Eq": "1 kg",
-    "keywords": [
-
-    ],
+    "keywords": [],
     "sources": [
       "https://www.vox.com/22787178/beyond-impossible-plant-based-vegetarian-meat-climate-environmental-impact-sustainability"
     ]
@@ -297,9 +237,7 @@
     "kind": "thing",
     "name": "Jean",
     "co2Eq": "20 kg",
-    "keywords": [
-
-    ],
+    "keywords": [],
     "sources": [
       "https://actions.sumofus.org/a/it-s-time-to-put-a-stop-the-the-denim-industry-s-dirty-secrets"
     ]
@@ -308,12 +246,36 @@
     "kind": "thing",
     "name": "Paperback book",
     "co2Eq": "2.71 kg",
-    "keywords": [
-      "book",
-      "paper"
-    ],
+    "keywords": ["book", "paper"],
     "sources": [
       "https://www.researchgate.net/profile/Achille-B-Laurent/publication/255699164_Carbon_Footprint_Assessment_of_a_Paperback_Book/links/5a004010a6fdcc93611d83f9/Carbon-Footprint-Assessment-of-a-Paperback-Book.pdf"
+    ]
+  },
+  {
+    "kind": "thing",
+    "name": "A bitcoin transaction",
+    "co2Eq": "370 kg",
+    "keywords": [],
+    "sources": [
+      "https://www.forbes.com/sites/philippsandner/2021/11/19/bitcoin-co2-emissions-from-an-investor-perspective-and-how-to-compensate-them/"
+    ]
+  },
+  {
+    "kind": "thing",
+    "name": "One howmuch.green page",
+    "co2Eq": "0.02 g",
+    "keywords": ["this website"],
+    "sources": [
+      "https://www.carbonbrief.org/factcheck-what-is-the-carbon-footprint-of-streaming-video-on-netflix"
+    ]
+  },
+  {
+    "kind": "thing",
+    "name": "1h of Netflix",
+    "co2Eq": "40 g",
+    "keywords": ["streaming", "youtube", "video"],
+    "sources": [
+      "https://www.carbonbrief.org/factcheck-what-is-the-carbon-footprint-of-streaming-video-on-netflix"
     ]
   }
 ]


### PR DESCRIPTION
This PR adds three new things:
- a bitcoin transaction
- a visit to howmuch.green
- one hour of streaming

It also updates the value of a kid impact: 59 tons was contested by multiple alternative studies. Stick to 1 ton for now. I also don't want the debates to focus on this. It's hard to evaluate anyway.

It's difficult to find accurate data, as multiple studies try to provide values for that, sometimes with a ×1000 difference 🤦 …

Also prettier reformatted the file: we should likely enforce some formatting to avoid this kind of change again and again in the future.